### PR TITLE
Fixed viewport warning.

### DIFF
--- a/lib/Ext.js
+++ b/lib/Ext.js
@@ -28,3 +28,7 @@ Ext.apply = function(object, config, defaults) {
     }
     return object;
 };
+
+// ExtJS debug mode will prompt a warning when this meta is not present in HEAD.
+// `Inject.rawHead` requires "meteorhacks:inject-initial" package.
+Inject.rawHead('ext-viewport', '<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">');

--- a/package.js
+++ b/package.js
@@ -14,6 +14,8 @@ Package.onUse(function(api) {
 
     api.use('fortawesome:fontawesome@4.3.0', 'client');
     api.use('iron:router@1.0.0');
+    // Used to inject content before anything else to head.
+    api.use('meteorhacks:inject-initial', 'server');
 
     api.addFiles([
         'extjs-5.1.1/resources/ext-theme-crisp-all_01.css',


### PR DESCRIPTION
ExtJS debug mode will prompt a warning when the correct viewport meta tag is not present in HEAD.
